### PR TITLE
・GameSceneManagerを変更し、ゲームオーバーを実装(現在NanaiSceneのみ)

### DIFF
--- a/Assets/Nanai/Scene/NanaiScene.unity
+++ b/Assets/Nanai/Scene/NanaiScene.unity
@@ -540,7 +540,7 @@ Transform:
   - {fileID: 565538655}
   - {fileID: 1754092119}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &268162598
 GameObject:
@@ -1461,7 +1461,7 @@ Transform:
   - {fileID: 222160457}
   - {fileID: 268162599}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &683262844
 GameObject:
@@ -10024,7 +10024,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1690872108
 MonoBehaviour:
@@ -10625,7 +10625,7 @@ Transform:
   m_LocalScale: {x: 1, y: 3.41, z: 8.41}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1958709519
 PrefabInstance:
@@ -10954,7 +10954,7 @@ Transform:
   m_LocalScale: {x: 40, y: 1, z: 40}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &2002873951
 BoxCollider:
@@ -12745,7 +12745,7 @@ Transform:
   - {fileID: 4593596735648366775}
   - {fileID: 4593596735560562006}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4593596735594430737
 GameObject:
@@ -12767,7 +12767,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!96 &4593596735594430738
 TrailRenderer:
   serializedVersion: 2
@@ -14146,7 +14146,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0be718b9ff315f4faa8451bb69c8386, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Target: {fileID: 4593596735594430737}
+  Target: {fileID: 8506136326504554172}
   FireInterval: 1.5
   FireRange: 30
   bullet: {fileID: 1168890653209775074, guid: f6c99557a944d9043b6e6b5c0c268731, type: 3}
@@ -14163,7 +14163,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3bc54a82e02116c4daa1aa370fff234d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Target: {fileID: 4593596735594430737}
+  Target: {fileID: 8506136326504554172}
   Spd: 0.2
   SensingRange: 20
   SpdChangeRange: 10
@@ -14436,6 +14436,75 @@ Transform:
   m_Father: {fileID: 6850518105273446744}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &6795120959230184625
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828225, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2902221866915828237, guid: 04484a426fc807a41bb9f27746ec64ae,
+        type: 3}
+      propertyPath: m_Name
+      value: Player_v2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 04484a426fc807a41bb9f27746ec64ae, type: 3}
 --- !u!4 &6850518105273446744
 Transform:
   m_ObjectHideFlags: 0
@@ -15085,6 +15154,12 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &8506136326504554172 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2902221866915828237, guid: 04484a426fc807a41bb9f27746ec64ae,
+    type: 3}
+  m_PrefabInstance: {fileID: 6795120959230184625}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8867995427824321525
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Nanai/Script/EnemyAChaseMove.cs
+++ b/Assets/Nanai/Script/EnemyAChaseMove.cs
@@ -64,6 +64,7 @@ public class EnemyAChaseMove : MonoBehaviour
             }
             else
             {
+                IsWalk = true;
                 Agent.SetDestination(Target.transform.position);
 
                 Vector3 dist = (Target.transform.position - this.transform.position).normalized;
@@ -74,7 +75,8 @@ public class EnemyAChaseMove : MonoBehaviour
                 Physics.Raycast(ray, out rayHit, SensingRange);
                 //Debug用Ray表示
                 Debug.DrawRay(ray.origin, ray.direction * SensingRange, Color.yellow, 1, false);
-                if (rayHit.collider.transform.GetInstanceID() == Target.transform.GetInstanceID())
+                //if (rayHit.collider.tag == "Player")
+                if (rayHit.collider.tag == Target.tag)
                 {
                     animator.SetBool("IsRunning", false);
                     animator.SetBool("IsFire", true);
@@ -103,7 +105,7 @@ public class EnemyAChaseMove : MonoBehaviour
                 //Debug用Ray表示
                 Debug.DrawRay(ray.origin, ray.direction * SensingRange, Color.red, 1, false);
                 //if (rayHit.collider.tag == "Player")
-                if (rayHit.collider.transform.GetInstanceID() == Target.transform.GetInstanceID())
+                if (rayHit.collider.tag == Target.tag)
                 {
                     Debug.Log("Target発見");
                     animator.SetBool("IsRunning", false);

--- a/Assets/Nanai/Script/EnemyShoot.cs
+++ b/Assets/Nanai/Script/EnemyShoot.cs
@@ -52,13 +52,14 @@ public class EnemyShoot : MonoBehaviour
         Physics.Raycast(ray, out rayHit, FireRange);
         //Debug用Ray表示
         Debug.DrawRay(ray.origin, ray.direction * FireRange, Color.blue, 1, false);
-        if (rayHit.collider == null || rayHit.collider.transform.GetInstanceID() != Target.transform.GetInstanceID())
+        if (rayHit.collider == null || rayHit.collider.tag != Target.tag)
         {
             ChaseMove.SetFireAnimation(false);
             ChaseMove.SetRunningAnimation(true);
             ChaseMove.SetFireFlag(false);
         }
-        if (rayHit.collider.transform.GetInstanceID() == Target.transform.GetInstanceID())
+        //if (rayHit.collider.tag == "Player")
+        if (rayHit.collider.tag == Target.tag)
         {
             //射撃SE再生
             SEManager.Instance.Play(SEPath.ENEMY_SHOOT2,0.5f);

--- a/Assets/Nanai/Script/GameSceneManager.cs
+++ b/Assets/Nanai/Script/GameSceneManager.cs
@@ -6,23 +6,43 @@ public class GameSceneManager : MonoBehaviour
 {
     int i;
     [SerializeField] int EnemyNum;
+    int State;//0=ゲーム中, 1=ゲームクリア, 2=ゲームオーバー
     // Start is called before the first frame update
     void Start()
     {
         i = 0;
+        State = 0;
     }
 
     // Update is called once per frame
     void Update()
     {
-        if (i >= EnemyNum)
+        if (State == 0)
+        {
+            if (i >= EnemyNum)
+            {
+                State = 2;
+            }
+        }
+        //GameClear
+        if(State == 1)
         {
             Debug.Log("GameClear,SceneChange");
+            //SceneManager.LoadScene("Scene_Game", LoadSceneMode.Single);
+        }
+        //GameOver
+        if (State == 2)
+        {
+            Debug.Log("GameOver,SceneChange");
             //SceneManager.LoadScene("Scene_Game", LoadSceneMode.Single);
         }
     }
     public void AddCount()
     {
         i += 1;
+    }
+    public void GameOver()
+    {
+        State = 2;
     }
 }

--- a/Assets/Nanai/Script/PlayerLife.cs
+++ b/Assets/Nanai/Script/PlayerLife.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerLife : MonoBehaviour
+{
+    GameObject GameSceneManagerObject;
+    GameSceneManager ManagerScript;
+    [SerializeField] int Life;
+    [SerializeField] int Damage;
+
+    void Start()
+    {
+        GameSceneManagerObject = GameObject.Find("SceneManager");
+        ManagerScript = GameSceneManagerObject.GetComponent<GameSceneManager>();
+    }
+    void Update()
+    {
+        if (Life <= 0)
+        {
+            ManagerScript.GameOver();
+        }
+    }
+    void OnCollisionEnter(Collision other)
+    {
+        //近接攻撃型の敵のこと全く考えてなかったけど後でどうにかしようね
+        if (other.gameObject.tag == "EnemyBullet")
+        {
+            Life -= Damage;
+        }
+    }
+}

--- a/Assets/Nanai/Script/PlayerLife.cs.meta
+++ b/Assets/Nanai/Script/PlayerLife.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd3e65f2ad7ca214e9580338e57802a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Nanai/Script/SPlayerStatusK.cs
+++ b/Assets/Nanai/Script/SPlayerStatusK.cs
@@ -1,0 +1,236 @@
+﻿//kanda 修正　34:bool追加 46:条件追加 48:bool真  49:※アウト  50:49に代わる関数呼び出し  60:bool偽
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SPlayerStatusK : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        gamepad = transform.gameObject.AddComponent<SGamePadAdjuster>();
+        //emitter = transform.Find(@"Body\Weapon\Emitter").gameObject;
+        pp = new SPropeller();
+        pp.Initialize(transform.Find("Body/PropellerFL"), transform.Find("Body/PropellerFR"),
+            transform.Find("Body/PropellerBL"), transform.Find("Body/PropellerBR"));
+
+        power_on = true;
+    }
+
+    // Update is called once per frame
+    /* Update func
+     * Key Update => Apply
+     */
+    void Update()
+    {
+        // 今は簡易的に操作を直書き
+        // 今後どうにかする
+
+        // キー処理
+        Vector3 direction = Vector3.zero;
+        float r = 0f;
+        bool isShot = false;
+        bool isTrigger = false; //ボタンを押したかの判定用
+
+        if (power_on)
+        {
+            // Shot
+            if (Input.GetKeyDown(KeyCode.Mouse1) || gamepad.RTrigger.trigger)
+            {
+                isShot = true;
+                Shot();
+            }
+
+            // PowerAccele
+            if (Input.GetKey(KeyCode.Space) || gamepad.Left.press || gamepad.Right.press || gamepad.Up.press || gamepad.Down.press || gamepad.Front.press || gamepad.Back.press || gamepad.LRot.press || gamepad.RRot.press)
+            {
+                isTrigger = true;   //ボタンを押した状態
+                //pp.Accele(gamepad.LTrigger.value);
+                pp.Accele(1.0f);
+
+                // ここにアクセル的なやつ
+                // 連動するのはドローンの起動レベルとプロペラの回転量
+                //transform.gameObject.GetComponent<Rigidbody>().useGravity = false;
+                //transform.gameObject.GetComponent<Rigidbody>().velocity = Vector3.zero;
+                //transform.gameObject.GetComponent<Rigidbody>().AddForce(new Vector3(0, 12f,0)*gamepad.LTrigger.value);
+            }
+            else
+            {
+                isTrigger = false;
+
+                //transform.gameObject.GetComponent<Rigidbody>().useGravity = true;
+                //Translate(Vector3.down);
+            }
+
+            if (isTrigger)
+            {
+                // Left
+                if (Input.GetKey(KeyCode.A) || gamepad.Left.press)
+                {
+                    direction.x = -0.2f;
+                }
+                // Right
+                if (Input.GetKey(KeyCode.D) || gamepad.Right.press)
+                {
+                    direction.x = 0.2f;
+                }
+
+                // Front
+                if (Input.GetKey(KeyCode.W) || gamepad.Front.press)
+                {
+                    direction.z = 0.2f;
+                }
+
+                // Back
+                if (Input.GetKey(KeyCode.S) || gamepad.Back.press)
+                {
+                    direction.z = -0.2f;
+                }
+
+                // Up
+                if (Input.GetKey(KeyCode.R) || gamepad.Up.press)
+                {
+                    direction.y = 0.3f;
+                }
+
+                // Down
+                if (Input.GetKey(KeyCode.F) || gamepad.Down.press)
+                {
+                    direction.y = -0.3f;
+                }
+
+                // Turn
+                if (Input.GetKey(KeyCode.Q) || gamepad.LRot.press)
+                {
+                    r += -2f;
+                }
+                if (Input.GetKey(KeyCode.E) || gamepad.RRot.press)
+                {
+                    r += 2f;
+                }
+            }
+
+
+
+
+        }
+
+
+
+        // 実行/Apply
+
+        //Translate(direction);
+        TranslateInertia(direction);
+        Rotate(r);
+
+
+
+
+        // Update
+        pp.Update();
+    }
+
+    // 平行移動
+    void Translate(Vector3 direction)
+    {
+        // 各軸移動量の算出
+        Vector3 vec = Vector3.zero;
+        vec += transform.forward * direction.z;
+        vec += transform.right * direction.x;
+        vec += transform.up * direction.y;
+
+        //transform.GetComponent<Rigidbody>().AddForce(speed * Time.deltaTime * vec * 10f);
+        //move += speed * Time.deltaTime * vec;
+        //move *= 0.99f;
+        //transform.localPosition += move;
+        transform.localPosition += vec * speed * Time.deltaTime;
+    }
+    void TranslateInertia(Vector3 direction)
+    {
+        // 各軸移動量の算出
+        Vector3 vec = Vector3.zero;
+        vec += transform.forward * direction.z;
+        vec += transform.right * direction.x;
+        vec += transform.up * direction.y;
+
+        transform.GetComponent<Rigidbody>().AddForce(speed * Time.deltaTime * vec * 100f);
+        transform.GetComponent<Rigidbody>().velocity *= 0.99f;
+    }
+
+    // 旋回
+    void Rotate(float lr)
+    {
+        // ここちゃんと組もうね
+        //transform.Rotate(new Vector3(0, lr, 0));
+        transform.eulerAngles += new Vector3(0f, lr * rot * Time.deltaTime, 0f);
+        //transform.localEulerAngles += new Vector3(0f, lr * rot * Time.deltaTime, 0f);
+    }
+
+    // 弾発射
+    void Shot()
+    {
+        GameObject go = Instantiate(bullet, emitter.transform.position, Quaternion.identity);
+        go.GetComponent<Rigidbody>().AddForce(transform.forward * 500);
+    }
+
+
+    /* 速度(1m/s) = accele */
+    [SerializeField]
+    private float speed = 1f;
+    /* 移動量 */
+    [SerializeField]
+    private Vector3 move = Vector3.zero;
+
+    /* バッテリー */
+    //[SerializeField] private float energy = 1.0f;
+    /* ECS */
+    //[SerializeField] private int ecs = 60;// よくわかんないから放置
+    /* プロペラ */
+    //[SerializeField] private float propera = 1.0f;
+
+    // 撃つ弾
+    [SerializeField]
+    private GameObject bullet = null;
+    // 発射口
+    [SerializeField]
+    private GameObject emitter = null;
+
+    private SGamePadAdjuster gamepad = null;
+    [SerializeField]
+    private float rot = 1f;
+
+    public SPropeller pp = null;
+    [SerializeField]
+    bool power_on = false;
+
+    private void OnCollisionExit(Collision collision)
+    {
+        if (collision.gameObject.CompareTag("PlayArea"))
+        {
+            power_on = false;
+        }
+    }
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.gameObject.CompareTag("PlayArea"))
+        {
+            power_on = false;
+        }
+    }
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        if (collision.gameObject.CompareTag("PlayArea"))
+        {
+            power_on = true;
+        }
+    }
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.gameObject.CompareTag("PlayArea"))
+        {
+            power_on = true;
+        }
+    }
+}

--- a/Assets/Nanai/Script/SPlayerStatusK.cs.meta
+++ b/Assets/Nanai/Script/SPlayerStatusK.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 467b5266e939c6f4084060a2268ec7f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefab/Player_v2.prefab
+++ b/Assets/Prefab/Player_v2.prefab
@@ -1,0 +1,642 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2902221866080817043
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2902221866080817042}
+  - component: {fileID: 2902221866080817041}
+  m_Layer: 0
+  m_Name: Weapon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2902221866080817042
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866080817043}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2902221866660687143}
+  m_Father: {fileID: 2902221866568563636}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2902221866080817041
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866080817043}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Size: {x: 0.2, y: 0.25, z: 0.7}
+  m_Center: {x: 0, y: 0.1, z: 0.2}
+--- !u!1 &2902221866178272619
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2902221866178272618}
+  - component: {fileID: 2902221866178272617}
+  m_Layer: 0
+  m_Name: PropellerFR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2902221866178272618
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866178272619}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.563, y: 0.32, z: 0.5125}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2902221866568563636}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2902221866178272617
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866178272619}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 0.05, z: 0.7}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &2902221866461597807
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2902221866461597806}
+  - component: {fileID: 2902221866461597805}
+  m_Layer: 0
+  m_Name: PropellerBL
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2902221866461597806
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866461597807}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.563, y: 0.32, z: -0.478}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2902221866568563636}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2902221866461597805
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866461597807}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 0.05, z: 0.7}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &2902221866568563637
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2902221866568563636}
+  - component: {fileID: 2902221866568563627}
+  m_Layer: 0
+  m_Name: Body
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2902221866568563636
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866568563637}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2902221866740153493}
+  - {fileID: 2902221866178272618}
+  - {fileID: 2902221866461597806}
+  - {fileID: 2902221867467300257}
+  - {fileID: 2902221866080817042}
+  m_Father: {fileID: 2902221866915828225}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2902221866568563627
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866568563637}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1.3, y: 0.35, z: 1.2}
+  m_Center: {x: 0, y: 0.175, z: 0}
+--- !u!1 &2902221866660687136
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2902221866660687143}
+  m_Layer: 0
+  m_Name: Emitter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2902221866660687143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866660687136}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.7}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2902221866080817042}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2902221866740153494
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2902221866740153493}
+  - component: {fileID: 2902221866740153492}
+  m_Layer: 0
+  m_Name: PropellerFL
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2902221866740153493
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866740153494}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.563, y: 0.32, z: 0.5125}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2902221866568563636}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2902221866740153492
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866740153494}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 0.05, z: 0.7}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &2902221866915828237
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2902221866915828225}
+  - component: {fileID: 2902221866915828227}
+  - component: {fileID: 2902221866915828226}
+  - component: {fileID: 2902221866915828337}
+  - component: {fileID: 2902221866915828236}
+  - component: {fileID: 2902221866915828224}
+  - component: {fileID: 2902221866915828238}
+  - component: {fileID: 2902221866915828239}
+  m_Layer: 0
+  m_Name: Player_v2
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2902221866915828225
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866915828237}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2902221867375187362}
+  - {fileID: 2902221866568563636}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &2902221866915828227
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866915828237}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 112
+  m_CollisionDetection: 0
+--- !u!114 &2902221866915828226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866915828237}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a9536301f89c36a41b29392bb1046463, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 30
+  move: {x: 0, y: 0, z: 0}
+  bullet: {fileID: 1143042785784274113, guid: 0a64bebe6a46aa94abd419f5c24bf70e, type: 3}
+  emitter: {fileID: 2902221866660687136}
+  rot: 25
+  pp:
+    angle: 0
+    to: 0
+    limitTake_off: 10
+  power_on: 0
+--- !u!114 &2902221866915828337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866915828237}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 467b5266e939c6f4084060a2268ec7f4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 30
+  move: {x: 0, y: 0, z: 0}
+  bullet: {fileID: 1143042785784274113, guid: 0a64bebe6a46aa94abd419f5c24bf70e, type: 3}
+  emitter: {fileID: 2902221866660687136}
+  rot: 25
+  pp:
+    angle: 0
+    to: 0
+    limitTake_off: 25
+  power_on: 0
+--- !u!114 &2902221866915828236
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866915828237}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 813244f33b69cd14d8ba2474f03b4c68, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bodyNum: 0
+  propellerNum: 0
+  weaponNum: 0
+  saveData: player.sd
+  body:
+  - {fileID: -927199367670048503, guid: 305efed8eaf7441488a28bd0c9e43833, type: 3}
+  propeller:
+  - {fileID: -927199367670048503, guid: 3cd23baa40b9de2489d481d4ca395830, type: 3}
+  - {fileID: -927199367670048503, guid: 23a240e97d4df9946a98a211a2487555, type: 3}
+  weapon:
+  - {fileID: -927199367670048503, guid: 13da238d69f25824fbcab145798c6bb0, type: 3}
+  - {fileID: -927199367670048503, guid: 43764453ba81e70438063db60ccc2899, type: 3}
+--- !u!114 &2902221866915828224
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866915828237}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 597c35341b649874a8eedc9e36fab3e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  angle: 0
+  accele: 0.216
+--- !u!114 &2902221866915828238
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866915828237}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd3e65f2ad7ca214e9580338e57802a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Life: 1
+  Damage: 1
+--- !u!96 &2902221866915828239
+TrailRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221866915828237}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 02ae38caa51899942b0545e7641c60f2, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Time: 3
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: -0.6833742
+        outSlope: -0.6833742
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.15064102
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: -0.3965142
+        outSlope: -0.3965142
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.26644772
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MinVertexDistance: 0.5
+  m_Autodestruct: 0
+  m_Emitting: 1
+--- !u!1 &2902221867375187363
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2902221867375187362}
+  - component: {fileID: 2902221867375187360}
+  - component: {fileID: 2902221867375187361}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2902221867375187362
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221867375187363}
+  m_LocalRotation: {x: 0.15272705, y: 0, z: 0, w: 0.98826844}
+  m_LocalPosition: {x: 0, y: 1.5, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2902221866915828225}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 17.57, y: 0, z: 0}
+--- !u!20 &2902221867375187360
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221867375187363}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &2902221867375187361
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221867375187363}
+  m_Enabled: 1
+--- !u!1 &2902221867467300258
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2902221867467300257}
+  - component: {fileID: 2902221867467300256}
+  m_Layer: 0
+  m_Name: PropellerBR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2902221867467300257
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221867467300258}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.563, y: 0.32, z: -0.478}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2902221866568563636}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2902221867467300256
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2902221867467300258}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 0.05, z: 0.7}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefab/Player_v2.prefab.meta
+++ b/Assets/Prefab/Player_v2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 04484a426fc807a41bb9f27746ec64ae
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
・PlayerのモデルをPlayer_v2に変更
・Playerモデルを差し替えたことに伴い、射撃型エネミーの移動スクリプト、攻撃スクリプトを一部変更
以下Player_v1からPlayer_2の変更点
・Playerに体力を実装
・操作のスクリプトをSPlayerStatusからSPlayerStatusKに変更
    ＬこれによってLトリガーを押しっぱなしにしなくてもスティック入力のみでプロペラが回転するように